### PR TITLE
Fix user model retrieval in ConfigService to handle missing configuration

### DIFF
--- a/src/Services/ConfigService.php
+++ b/src/Services/ConfigService.php
@@ -33,8 +33,15 @@ readonly class ConfigService
 
     public static function getUserModel(): string
     {
+        if (! config('oltrematica-role-lite.model_names.user')) {
+            /** @var string $config */
+            $config = config('auth.providers.users.model', 'App\Models\User');
+
+            return $config;
+        }
+
         /** @var string $model */
-        $model = config('oltrematica-role-lite.model_names.user', config('auth.providers.users.model', 'App\Models\User'));
+        $model = config('oltrematica-role-lite.model_names.user', 'App\Models\User');
 
         return $model;
     }


### PR DESCRIPTION
This pull request includes a change to the `src/Services/ConfigService.php` file to improve the handling of the user model configuration. The most important change is the addition of a conditional check to ensure the `oltrematica-role-lite.model_names.user` configuration exists before attempting to use it.

* Added a conditional check in the `getUserModel` method to verify if the `oltrematica-role-lite.model_names.user` configuration is set. If not, it defaults to using the `auth.providers.users.model` configuration or the `App\Models\User` model.