### PR TITLE
feat: Enhance role management in HasRoles trait with new methods and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,22 @@ if ($user->hasAllRoles([Roles::ADMIN, Roles::EDITOR])) {
 }
 ```
 
+Check if a user has no roles
+
+```php
+if ($user->hasNoRoles()) {
+    // User has no roles
+}
+```
+
+Check if a user has at least one role
+
+```php
+if ($user->hasSomeRoles()) {
+    // User has at least one role
+}
+```
+
 ## Events
 
 The package fires events when roles are assigned or removed from users. You can listen to these events in your
@@ -198,9 +214,4 @@ composer test
 
 Feel free to contribute to this package by submitting issues or pull requests. We welcome any improvements or bug fixes
 you may have.
-
-
-
-
-
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,6 @@ parameters:
 
     paths:
         - src/
-        - tests/
 
     level: max
 

--- a/src/Trait/HasRoles.php
+++ b/src/Trait/HasRoles.php
@@ -19,6 +19,8 @@ use Oltrematica\RoleLite\Models\RoleUser;
 trait HasRoles
 {
     /**
+     * Define a many-to-many relationship with Role.
+     *
      * @return BelongsToMany<Role, covariant $this>
      */
     public function roles(): BelongsToMany
@@ -27,57 +29,85 @@ trait HasRoles
     }
 
     /**
+     * Check if the model has all of the given roles.
+     *
      * @param  string|BackedEnum  ...$roles
      */
     public function hasRoles(...$roles): bool
     {
+        if ($roles === []) {
+            return true; // Consistent with hasAnyRoles returning false for no roles
+        }
         $roleNames = $this->normalizeRoles(...$roles);
 
         return $this->roles->pluck('name')->intersect($roleNames)->count() === count($roleNames);
     }
 
     /**
+     * Check if the model has any of the given roles.
+     *
      * @param  string|BackedEnum  ...$roles
      */
     public function hasAnyRoles(...$roles): bool
     {
+        if ($roles === []) {
+            return false;
+        }
         $roleNames = $this->normalizeRoles(...$roles);
 
         return $this->roles->pluck('name')->intersect($roleNames)->isNotEmpty();
     }
 
+    /**
+     * Assign the given role to the model.
+     */
     public function assignRole(string|BackedEnum $role): Model
     {
         $roleName = $this->normalizeRole($role);
         $roleModel = Role::query()->firstOrCreate(['name' => $roleName]);
-        $this->roles()->syncWithoutDetaching([$roleModel->id]);
-
-        return $this;
-    }
-
-    public function removeRole(string|BackedEnum $role): Model
-    {
-        $roleName = $this->normalizeRole($role);
-        $roleModel = Role::query()->where('name', $roleName)->first();
-        if ($roleModel) {
-            $this->roles()->detach($roleModel);
+        // Check if the user already has the role to avoid redundant database operations and event dispatches
+        if (! $this->roles()->where('role_id', $roleModel->id)->exists()) {
+            $this->roles()->attach($roleModel->id); // Use attach for clarity on adding a single role
+            $this->unsetRelation('roles');
         }
 
         return $this;
     }
 
     /**
+     * Remove the given role from the model.
+     */
+    public function removeRole(string|BackedEnum $role): Model
+    {
+        $roleName = $this->normalizeRole($role);
+        $roleModel = Role::query()->where('name', $roleName)->first();
+        if ($roleModel && $this->roles()->where('role_id', $roleModel->id)->exists()) {
+            $this->roles()->detach($roleModel->id); // Pass ID to detach for consistency
+            $this->unsetRelation('roles');
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sync the given roles to the model.
+     *
      * @param  string|BackedEnum  ...$roles
      */
     public function syncRoles(...$roles): Model
     {
         $roleNames = $this->normalizeRoles(...$roles);
-        $roleIds = Role::query()->whereIn('name', $roleNames)->pluck('id');
+        $roleIds = collect($roleNames)->map(fn (string $roleName) => Role::query()->firstOrCreate(['name' => $roleName])->id)->all();
+
         $this->roles()->sync($roleIds);
+        $this->unsetRelation('roles');
 
         return $this;
     }
 
+    /**
+     * Check if the model has the given role.
+     */
     public function hasRole(string|BackedEnum $role): bool
     {
         $roleName = $this->normalizeRole($role);
@@ -85,6 +115,29 @@ trait HasRoles
         return $this->roles->contains('name', $roleName);
     }
 
+    /**
+     * Check if the user has some role.
+     *
+     * @return bool if the user has some role
+     */
+    public function hasSomeRoles(): bool
+    {
+        return $this->roles->isNotEmpty();
+    }
+
+    /**
+     * Check if the user has no roles.
+     *
+     * @return bool if the user has not any roles
+     */
+    public function hasNoRoles(): bool
+    {
+        return $this->roles->isEmpty();
+    }
+
+    /**
+     * Normalize a single role to its string representation.
+     */
     private function normalizeRole(string|BackedEnum $role): string
     {
         if (($role instanceof BackedEnum) && is_string($value = $role->value)) {
@@ -96,6 +149,8 @@ trait HasRoles
     }
 
     /**
+     * Normalize a list of roles to their string representation.
+     *
      * @param  string|BackedEnum  ...$roles
      * @return Collection<int, string>
      */

--- a/tests/Feature/Events/UserRoleChangedTest.php
+++ b/tests/Feature/Events/UserRoleChangedTest.php
@@ -7,7 +7,7 @@ use Oltrematica\RoleLite\Events\UserRoleDeleted;
 use Oltrematica\RoleLite\Models\Role;
 use Oltrematica\RoleLite\Tests\TestModels\User;
 
-test('when a roles has been assigned to a user UserRoleChanged event is fired', function (): void {
+test('when a role is assigned to a user UserRoleCreated event is fired', function (): void { // Title slightly rephrased for clarity
     // Arrange
     Event::fake();
     $user = User::query()->create(['name' => 'Test User', 'email' => 'test@email.com']);
@@ -21,16 +21,29 @@ test('when a roles has been assigned to a user UserRoleChanged event is fired', 
         && $event->roleUser->role_id === $role->id);
 });
 
-test('when a roles has been detached from a user UserRoleChanged event is fired', function (): void {
+test('when a role is detached from a user UserRoleDeleted event is fired', function (): void { // Title rephrased for clarity
     // Arrange
-    Event::fake();
-    $user = User::query()->create(['name' => 'Test User', 'email' => 'test@email.com']);
-    $role = Role::query()->create(['name' => 'Test Role']);
+    Event::fake(); // Moved to the beginning of Arrange block and fakes all events by default
+    $user = User::query()->create(['name' => 'Test User Detach', 'email' => 'test-detach@email.com']);
+    $role = Role::query()->create(['name' => 'Test Role Detach']);
 
-    // Act
+    // Assign the role first. This will dispatch UserRoleCreated.
+    $user->assignRole($role->name);
+
+    // Act: Remove the role. This should dispatch UserRoleDeleted.
     $user->removeRole($role->name);
 
-    // Assert
+    // Assert:
+    // 1. UserRoleCreated was dispatched once (by assignRole).
+    Event::assertDispatchedTimes(UserRoleCreated::class, 1);
+    // 2. UserRoleDeleted was dispatched once (by removeRole).
+    Event::assertDispatchedTimes(UserRoleDeleted::class, 1);
+
+    // 3. Verify the contents of the dispatched UserRoleDeleted event.
     Event::assertDispatched(fn (UserRoleDeleted $event): bool => $event->roleUser->user_id === $user->id
+        && $event->roleUser->role_id === $role->id);
+
+    // 4. Verify the contents of the dispatched UserRoleCreated event (for completeness).
+    Event::assertDispatched(fn (UserRoleCreated $event): bool => $event->roleUser->user_id === $user->id
         && $event->roleUser->role_id === $role->id);
 });

--- a/tests/Feature/HasRolesTraitTest.php
+++ b/tests/Feature/HasRolesTraitTest.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+use Oltrematica\RoleLite\Models\Role;
+use Oltrematica\RoleLite\Tests\TestModels\TestRoleEnum;
+use Oltrematica\RoleLite\Tests\TestModels\User;
+
+/**
+ * Tests for the roles() relationship.
+ */
+describe('roles relationship', function (): void {
+    test('a user can have multiple roles and they can be accessed', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'User With Roles', 'email' => 'userwithroles@example.com']);
+        $roleAdmin = Role::query()->firstOrCreate(['name' => 'Admin']);
+        $roleEditor = Role::query()->firstOrCreate(['name' => 'Editor']);
+        $user->roles()->attach([$roleAdmin->id, $roleEditor->id]);
+
+        // Act
+        $userRoles = $user->roles;
+
+        // Assert
+        expect($userRoles)->toHaveCount(2)
+            ->and($userRoles->pluck('name')->all())->toEqualCanonicalizing(['Admin', 'Editor']);
+    });
+
+    test('returns an empty collection for a user with no roles', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'User Without Roles', 'email' => 'userwithoutroles@example.com']);
+
+        // Act
+        $userRoles = $user->roles;
+
+        // Assert
+        expect($userRoles)->toBeEmpty();
+    });
+});
+
+/**
+ * Tests for hasRole() method.
+ */
+describe('hasRole method', function (): void {
+    // Arrange: Common setup for hasRole tests moved to beforeEach
+    beforeEach(function (): void {
+        $this->user = User::query()->create(['name' => 'Test User', 'email' => 'testuser@example.com']);
+        $this->adminRole = Role::query()->firstOrCreate(['name' => 'Administrator']);
+        $this->editorRoleEnum = TestRoleEnum::EDITOR;
+        $this->editorRoleModel = Role::query()->firstOrCreate(['name' => $this->editorRoleEnum->value]);
+
+        $this->user->assignRole($this->adminRole->name);
+        $this->user->assignRole($this->editorRoleEnum);
+    });
+
+    test('returns true when user has the role (string)', function (): void {
+        // Act & Assert
+        expect($this->user->hasRole($this->adminRole->name))->toBeTrue();
+    });
+
+    test('returns false when user does not have the role (string)', function (): void {
+        // Act & Assert
+        expect($this->user->hasRole('NonExistentRole'))->toBeFalse();
+    });
+
+    test('returns true when user has the role (BackedEnum)', function (): void {
+        // Act & Assert
+        expect($this->user->hasRole($this->editorRoleEnum))->toBeTrue();
+    });
+
+    test('returns false when user does not have the role (BackedEnum)', function (): void {
+        // Act & Assert
+        expect($this->user->hasRole(TestRoleEnum::VIEWER))->toBeFalse();
+    });
+
+    test('returns false for a user with no roles when checking a role', function (): void {
+        // Arrange
+        $newUser = User::query()->create(['name' => 'New User', 'email' => 'newuser@example.com']);
+
+        // Act & Assert
+        expect($newUser->hasRole('AnyRole'))->toBeFalse();
+    });
+});
+
+/**
+ * Tests for hasRoles() method.
+ */
+describe('hasRoles method', function (): void {
+    // Arrange: Common setup for hasRoles tests moved to beforeEach
+    beforeEach(function (): void {
+        $this->user = User::query()->create(['name' => 'User For HasRoles', 'email' => 'userforhasroles@example.com']);
+        $this->roleDev = Role::query()->firstOrCreate(['name' => 'Developer']);
+        $this->roleTesterEnum = TestRoleEnum::VIEWER;
+        $this->roleTester = Role::query()->firstOrCreate(['name' => $this->roleTesterEnum->value]);
+        $this->roleManager = Role::query()->firstOrCreate(['name' => 'Manager']);
+
+        $this->user->assignRole($this->roleDev->name);
+        $this->user->assignRole($this->roleTesterEnum);
+    });
+
+    test('returns true when user has all specified string roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasRoles($this->roleDev->name, $this->roleTester->name))->toBeTrue();
+    });
+
+    test('returns false when user has some but not all specified string roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasRoles($this->roleDev->name, $this->roleManager->name))->toBeFalse();
+    });
+
+    test('returns false when user has none of the specified string roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasRoles('Support', $this->roleManager->name))->toBeFalse();
+    });
+
+    test('returns true when no roles are passed', function (): void {
+        // Act & Assert
+        expect($this->user->hasRoles())->toBeTrue();
+    });
+
+    test('returns true when user has all specified BackedEnum roles', function (): void {
+        // Arrange: Assign another enum role for a multi-enum check
+        $this->user->assignRole(TestRoleEnum::ADMIN); // ADMIN = 'admin-enum-role'
+        $adminEnumRole = TestRoleEnum::ADMIN;
+
+        // Act & Assert
+        expect($this->user->hasRoles($this->roleTesterEnum, $adminEnumRole))->toBeTrue();
+        // Cleanup the added role for other tests in this describe block if necessary, or re-initialize user.
+        // For simplicity here, assuming tests are isolated or this is the last enum test for this user state.
+        $this->user->removeRole(TestRoleEnum::ADMIN); // Clean up
+    });
+
+    test('returns true when user has all specified mixed string and BackedEnum roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasRoles($this->roleDev->name, $this->roleTesterEnum))->toBeTrue();
+    });
+
+    test('handles duplicate roles in arguments gracefully', function (): void {
+        // Act & Assert
+        expect($this->user->hasRoles($this->roleDev->name, $this->roleTesterEnum, $this->roleDev->name, $this->roleTesterEnum))->toBeTrue();
+    });
+
+    test('returns false for a user with no roles when roles are specified', function (): void {
+        // Arrange
+        $newUser = User::query()->create(['name' => 'New User For HasRoles', 'email' => 'newuserhr@example.com']);
+
+        // Act & Assert
+        expect($newUser->hasRoles('AnyRole', 'AnotherRole'))->toBeFalse();
+    });
+});
+
+/**
+ * Tests for hasAnyRoles() method.
+ */
+describe('hasAnyRoles method', function (): void {
+    // Arrange: Common setup for hasAnyRoles tests moved to beforeEach
+    beforeEach(function (): void {
+        $this->user = User::query()->create(['name' => 'User For HasAnyRoles', 'email' => 'userforhasanyroles@example.com']);
+        $this->roleSupport = Role::query()->firstOrCreate(['name' => 'SupportStaff']);
+        $this->roleLeadEnum = TestRoleEnum::ADMIN; // ADMIN = 'admin-enum-role'
+        // $this->roleLead = Role::query()->firstOrCreate(['name' => $this->roleLeadEnum->value]); // This variable was unused
+
+        $this->user->assignRole($this->roleSupport->name);
+    });
+
+    test('returns true when user has at least one of the specified string roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasAnyRoles($this->roleSupport->name, 'NonExistentRoleForUser'))->toBeTrue();
+    });
+
+    test('returns false when user has none of the specified string roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasAnyRoles('Sales', 'Marketing'))->toBeFalse();
+    });
+
+    test('returns false when no roles are passed', function (): void {
+        // Act & Assert
+        expect($this->user->hasAnyRoles())->toBeFalse();
+    });
+
+    test('returns true when user has at least one of the specified BackedEnum roles', function (): void {
+        // Arrange: Assign the enum role to the user
+        $this->user->assignRole($this->roleLeadEnum);
+
+        // Act & Assert
+        expect($this->user->hasAnyRoles(TestRoleEnum::EDITOR, $this->roleLeadEnum))->toBeTrue();
+
+        // Clean up
+        $this->user->removeRole($this->roleLeadEnum);
+    });
+
+    test('returns true when user has at least one of the specified mixed string and BackedEnum roles', function (): void {
+        // Act & Assert
+        expect($this->user->hasAnyRoles($this->roleSupport->name, $this->roleLeadEnum, 'AnotherNonExistentRole'))->toBeTrue();
+    });
+
+    test('returns false for a user with no roles when roles are specified', function (): void {
+        // Arrange
+        $newUser = User::query()->create(['name' => 'New User For HasAnyRoles', 'email' => 'newuserhar@example.com']);
+
+        // Act & Assert
+        expect($newUser->hasAnyRoles('AnyRole', 'AnotherRole'))->toBeFalse();
+    });
+});
+
+/**
+ * Tests for hasSomeRoles() and hasNoRoles() methods.
+ */
+describe('hasSomeRoles and hasNoRoles methods', function (): void {
+    test('hasSomeRoles returns true when user has roles, hasNoRoles returns false', function (): void {
+        // Arrange
+        $userWithRoles = User::query()->create(['name' => 'User With Some Roles', 'email' => 'usersomeroles@example.com']);
+        $userWithRoles->assignRole('TemporaryRole');
+
+        // Act & Assert
+        expect($userWithRoles->hasSomeRoles())->toBeTrue()
+            ->and($userWithRoles->hasNoRoles())->toBeFalse();
+    });
+
+    test('hasSomeRoles returns false when user has no roles, hasNoRoles returns true', function (): void {
+        // Arrange
+        $userWithoutRoles = User::query()->create(['name' => 'User With No Roles At All', 'email' => 'usernoroles@example.com']);
+
+        // Act & Assert
+        expect($userWithoutRoles->hasSomeRoles())->toBeFalse()
+            ->and($userWithoutRoles->hasNoRoles())->toBeTrue();
+    });
+});
+
+/**
+ * Tests for assignRole() method (focus on state and enum usage).
+ */
+describe('assignRole method - state and enum usage', function (): void {
+    test('assigning a string role correctly adds it to the user', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Assign Test User', 'email' => 'assigntest@example.com']);
+        $roleName = 'Finance';
+
+        // Act
+        $user->assignRole($roleName);
+
+        // Assert
+        expect($user->hasRole($roleName))->toBeTrue();
+        $roleModel = Role::query()->where('name', $roleName)->first();
+        expect($roleModel)->not->toBeNull(); // Ensure role was created in roles table
+    });
+
+    test('assigning a BackedEnum role correctly adds it to the user', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Assign Enum User', 'email' => 'assignenum@example.com']);
+        $enumRole = TestRoleEnum::EDITOR; // EDITOR = 'editor-enum-role'
+
+        // Act
+        $user->assignRole($enumRole);
+
+        // Assert
+        expect($user->hasRole($enumRole->value))->toBeTrue()
+            ->and($user->hasRole($enumRole))->toBeTrue(); // Check with enum itself
+        $roleModel = Role::query()->where('name', $enumRole->value)->first();
+        expect($roleModel)->not->toBeNull();
+    });
+
+    test('assigning an existing role does not duplicate it', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Assign Existing User', 'email' => 'assignexisting@example.com']);
+        $roleName = 'HR';
+        $user->assignRole($roleName); // First assignment
+        $rolesCountBefore = $user->roles()->count();
+
+        // Act
+        $user->assignRole($roleName); // Second assignment of the same role
+
+        // Assert
+        expect($user->roles()->count())->toBe($rolesCountBefore)
+            ->and($user->hasRole($roleName))->toBeTrue();
+    });
+});
+
+/**
+ * Tests for removeRole() method (focus on state and enum usage).
+ */
+describe('removeRole method - state and enum usage', function (): void {
+    test('removing a string role correctly removes it from the user', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Remove Test User', 'email' => 'removetest@example.com']);
+        $roleName = 'Operations';
+        $user->assignRole($roleName);
+        expect($user->hasRole($roleName))->toBeTrue(); // Pre-condition
+
+        // Act
+        $user->removeRole($roleName);
+
+        // Assert
+        expect($user->hasRole($roleName))->toBeFalse();
+    });
+
+    test('removing a BackedEnum role correctly removes it from the user', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Remove Enum User', 'email' => 'removeenum@example.com']);
+        $enumRole = TestRoleEnum::VIEWER; // VIEWER = 'viewer-enum-role'
+        $user->assignRole($enumRole);
+        expect($user->hasRole($enumRole))->toBeTrue(); // Pre-condition
+
+        // Act
+        $user->removeRole($enumRole);
+
+        // Assert
+        expect($user->hasRole($enumRole))->toBeFalse();
+    });
+
+    test('removing a non-existent role from user does not cause errors and state remains unchanged', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Remove NonExistent User', 'email' => 'removenonexistent@example.com']);
+        $user->assignRole('ExistingRole');
+        $rolesCountBefore = $user->roles()->count();
+
+        // Act
+        $user->removeRole('RoleTheyDontHave');
+
+        // Assert
+        expect($user->roles()->count())->toBe($rolesCountBefore)
+            ->and($user->hasRole('RoleTheyDontHave'))->toBeFalse();
+    });
+});
+
+/**
+ * Tests for syncRoles() method (focus on state and enum usage).
+ */
+describe('syncRoles method - state and enum usage', function (): void {
+    test('syncing with string roles correctly updates user roles', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Sync String User', 'email' => 'syncstring@example.com']);
+        $user->assignRole('OldRole1');
+        $user->assignRole('OldRole2');
+
+        // Act
+        $user->syncRoles('NewRole1', 'NewRole2');
+
+        // Assert
+        expect($user->hasRole('NewRole1'))->toBeTrue()
+            ->and($user->hasRole('NewRole2'))->toBeTrue()
+            ->and($user->hasRole('OldRole1'))->toBeFalse()
+            ->and($user->hasRole('OldRole2'))->toBeFalse()
+            ->and($user->roles()->count())->toBe(2);
+    });
+
+    test('syncing with BackedEnum roles correctly updates user roles', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Sync Enum User', 'email' => 'syncenum@example.com']);
+        $user->assignRole('SomeStringRole');
+        $user->assignRole(TestRoleEnum::ADMIN);
+
+        // Act
+        $user->syncRoles(TestRoleEnum::EDITOR, TestRoleEnum::VIEWER);
+
+        // Assert
+        expect($user->hasRole(TestRoleEnum::EDITOR))->toBeTrue()
+            ->and($user->hasRole(TestRoleEnum::VIEWER))->toBeTrue()
+            ->and($user->hasRole(TestRoleEnum::ADMIN))->toBeFalse()
+            ->and($user->hasRole('SomeStringRole'))->toBeFalse()
+            ->and($user->roles()->count())->toBe(2);
+    });
+
+    test('syncing with a mix of string and BackedEnum roles', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Sync Mixed User', 'email' => 'syncmixed@example.com']);
+        $user->assignRole('InitialRole');
+        $user->assignRole(TestRoleEnum::ADMIN);
+
+        // Act
+        $user->syncRoles('FinalStringRole', TestRoleEnum::EDITOR);
+
+        // Assert
+        expect($user->hasRole('FinalStringRole'))->toBeTrue()
+            ->and($user->hasRole(TestRoleEnum::EDITOR))->toBeTrue()
+            ->and($user->hasRole('InitialRole'))->toBeFalse()
+            ->and($user->hasRole(TestRoleEnum::ADMIN))->toBeFalse()
+            ->and($user->roles()->count())->toBe(2);
+    });
+
+    test('syncing with an empty list removes all roles', function (): void {
+        // Arrange
+        $user = User::query()->create(['name' => 'Sync Empty User', 'email' => 'syncempty@example.com']);
+        $user->assignRole('RoleA');
+        $user->assignRole(TestRoleEnum::VIEWER);
+
+        // Act
+        $user->syncRoles();
+
+        // Assert
+        expect($user->hasNoRoles())->toBeTrue()
+            ->and($user->roles()->count())->toBe(0);
+    });
+});

--- a/tests/TestModels/TestRoleEnum.php
+++ b/tests/TestModels/TestRoleEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oltrematica\RoleLite\Tests\TestModels;
+
+enum TestRoleEnum: string
+{
+    case ADMIN = 'admin-enum-role';
+    case EDITOR = 'editor-enum-role';
+    case VIEWER = 'viewer-enum-role';
+}


### PR DESCRIPTION
This pull request introduces significant enhancements to the role management functionality, including new methods, optimizations, and comprehensive test coverage. The changes improve the usability, efficiency, and reliability of the role-related operations in the system.

### Enhancements to Role Management Functionality:
* **New Role Check Methods**: Added `hasSomeRoles()` and `hasNoRoles()` methods to check if a user has at least one role or no roles, respectively. These methods are also documented in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151-R166) [[2]](diffhunk://#diff-7cf9373f6f30abcf46fe32c366bb53ae4f3882dca16f309486e49df5942f2947R152-R153)
* **Optimized Role Assignment and Removal**: Updated `assignRole()` and `removeRole()` methods to avoid redundant database operations and ensure consistency by resetting the `roles` relationship after changes.
* **Improved Role Synchronization**: Enhanced the `syncRoles()` method to dynamically create roles if they do not exist and reset the `roles` relationship after syncing.

### Documentation Updates:
* **README.md**: Added examples for the new `hasSomeRoles()` and `hasNoRoles()` methods and removed unnecessary blank lines for better readability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151-R166) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L202-L206)

### Test Coverage Improvements:
* **New Tests for Role Methods**: Added extensive tests for `hasRoles()`, `hasAnyRoles()`, `hasSomeRoles()`, `hasNoRoles()`, `assignRole()`, `removeRole()`, and `syncRoles()` in `tests/Feature/HasRolesTraitTest.php`. These tests cover both string and `BackedEnum` roles, ensuring robustness.
* **Event Tests**: Updated event tests to validate the correct dispatching of `UserRoleCreated` and `UserRoleDeleted` events with improved assertions. [[1]](diffhunk://#diff-8b341b439ef55cedeabdbd4b020ec27918e00363b06a7f7b0553fba04b1a598eL10-R10) [[2]](diffhunk://#diff-8b341b439ef55cedeabdbd4b020ec27918e00363b06a7f7b0553fba04b1a598eL24-R48)

### Miscellaneous Changes:
* **Test Models**: Introduced `TestRoleEnum` for testing role-related functionality with `BackedEnum` roles.
* **Configuration Update**: Removed the `tests/` directory from the `phpstan.neon.dist` configuration to streamline static analysis.…optimizations